### PR TITLE
Fixed reading the data within the block

### DIFF
--- a/scsi/src/main/java/net/alphadev/usbstorage/bbb/BulkBlockDevice.java
+++ b/scsi/src/main/java/net/alphadev/usbstorage/bbb/BulkBlockDevice.java
@@ -189,8 +189,10 @@ public class BulkBlockDevice implements BlockDevice {
         final int blocksPerTransfer = mMaxTransferSize / mBlockSize;
 
         int offsetBlocks = (int) (offsetBytes / mBlockSize);
+        int blockOffset = (int) (offsetBytes % mBlockSize);
         int blocksLeft = (short) Math.ceil((float) buffer.remaining() / mBlockSize);
 
+        boolean isFirstBlock = true;
         while (blocksLeft > 0) {
             final short requestedBlocks = (short) Math.min(blocksPerTransfer, blocksLeft);
             final int requestedSize = requestedBlocks * mBlockSize;
@@ -205,8 +207,10 @@ public class BulkBlockDevice implements BlockDevice {
                 final byte[] buf = mAbstractBulkDevice.read(mBlockSize);
 
                 if (blocksLeft-- > 0) {
-                    final int subLength = Math.min(mBlockSize, buffer.remaining());
-                    buffer.put(buf, 0, subLength);
+                    final int subLength = Math.min(mBlockSize - (isFirstBlock ? blockOffset : 0), buffer.remaining());
+                    buffer.put(buf, (isFirstBlock ? blockOffset : 0), subLength);
+
+                    isFirstBlock = false;
                 }
             }
 


### PR DESCRIPTION
Hello Jan!

Thanks for drive-mount library. Good work!
Your library helps me to deal with USB device, but I noticed a bug with `BulkBlockDevice` class when we are reading the data _within_ the block. So I fixed this bug and suggested you this pull request.

I know that the library has no changes last time. All I would like to help the others devs avoid this issue with your amazing library!

Thanks.
